### PR TITLE
Add option for new schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Add option to specify a schema name [#44](https://github.com/policy-design-lab/data-ingestion/issues/44)
+
 ## [0.4.1] - 2024-11-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ options:
   --create-database, -C
                         Construct database if it does not exist.
   --create-schema, -S   Create schema if it does not exist.
+  --schema-name, -N     New schema name, default pdl.
   --init-tables, -i     Initialize tables
   --insert-data, -I     Insert data
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 
 ```bash
 usage: main.py [-h] --db_name DB_NAME [--db_user DB_USER] [--db_password DB_PASSWORD] [--db_host DB_HOST] [--db_port DB_PORT] [--drop_existing] [--log_level LOG_LEVEL] [--create-tables] [--create-database] [--create-schema]
-               [--init-tables] [--insert-data]
+               [--schema-name SCHEMA_NAME] [--init-tables] [--insert-data]
 
 Create a PostgreSQL database and tables, and insert/update data into the tables.
 
@@ -34,7 +34,8 @@ options:
   --create-database, -C
                         Construct database if it does not exist.
   --create-schema, -S   Create schema if it does not exist.
-  --schema-name, -N     New schema name, default pdl.
+  --schema-name SCHEMA_NAME, -N SCHEMA_NAME
+                        Name of the new schema, default pdl.
   --init-tables, -i     Initialize tables
   --insert-data, -I     Insert data
 ```

--- a/queries/create_tables.sql
+++ b/queries/create_tables.sql
@@ -3,7 +3,7 @@
 BEGIN;
 
 
-CREATE TABLE IF NOT EXISTS pdl.titles
+CREATE TABLE IF NOT EXISTS ${SCHEMA}.titles
 (
     id          smallint               NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 100 MINVALUE 100 MAXVALUE 1000 CACHE 1 ),
     name        character varying(100) NOT NULL,
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS pdl.titles
     CONSTRAINT uc_title_name UNIQUE (name)
 );
 
-CREATE TABLE IF NOT EXISTS pdl.programs
+CREATE TABLE IF NOT EXISTS ${SCHEMA}.programs
 (
     id          smallint NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 100 MINVALUE 100 MAXVALUE 1000 CACHE 1 ),
     title_id    smallint,
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS pdl.programs
     CONSTRAINT pk_programs PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS pdl.sub_programs
+CREATE TABLE IF NOT EXISTS ${SCHEMA}.sub_programs
 (
     id         smallint NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 100 MINVALUE 100 MAXVALUE 10000 CACHE 1 ),
     program_id smallint NOT NULL,
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS pdl.sub_programs
     CONSTRAINT pk_sub_programs PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS pdl.payments
+CREATE TABLE IF NOT EXISTS ${SCHEMA}.payments
 (
     id                        bigint               NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 100 MINVALUE 100 MAXVALUE 1000000 CACHE 1 ),
     title_id                  smallint,
@@ -59,14 +59,14 @@ CREATE TABLE IF NOT EXISTS pdl.payments
     CONSTRAINT uc_payments UNIQUE (title_id, subtitle_id, program_id, sub_program_id, state_code, year)
 );
 
-CREATE TABLE IF NOT EXISTS pdl.states
+CREATE TABLE IF NOT EXISTS ${SCHEMA}.states
 (
     code character varying(2)   NOT NULL,
     name character varying(100) NOT NULL,
     CONSTRAINT pk_states PRIMARY KEY (code)
 );
 
-CREATE TABLE IF NOT EXISTS pdl.subtitles
+CREATE TABLE IF NOT EXISTS ${SCHEMA}.subtitles
 (
     id       smallint               NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 100 MINVALUE 100 MAXVALUE 1000 ),
     title_id smallint               NOT NULL,
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS pdl.subtitles
     CONSTRAINT pk_subtitles PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS pdl.practice_categories
+CREATE TABLE IF NOT EXISTS ${SCHEMA}.practice_categories
 (
     id                    smallint          NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 100 MINVALUE 100 MAXVALUE 1000 ),
     name                  character varying NOT NULL,
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS pdl.practice_categories
     PRIMARY KEY (id)
 );
 
-CREATE TABLE IF NOT EXISTS pdl.practices
+CREATE TABLE IF NOT EXISTS ${SCHEMA}.practices
 (
     code         character varying(100) NOT NULL,
     name         character varying(200) NOT NULL,
@@ -94,10 +94,10 @@ CREATE TABLE IF NOT EXISTS pdl.practices
     CONSTRAINT pk_practices PRIMARY KEY (code)
 );
 
-COMMENT ON TABLE pdl.practices
+COMMENT ON TABLE ${SCHEMA}.practices
     IS 'Conservation Practice Standards';
 
-CREATE TABLE IF NOT EXISTS pdl.sub_sub_programs
+CREATE TABLE IF NOT EXISTS ${SCHEMA}.sub_sub_programs
 (
     id             smallint NOT NULL GENERATED ALWAYS AS IDENTITY ( INCREMENT 1 START 100 MINVALUE 100 MAXVALUE 10000 ),
     sub_program_id smallint NOT NULL,
@@ -105,113 +105,113 @@ CREATE TABLE IF NOT EXISTS pdl.sub_sub_programs
     CONSTRAINT pk_sub_sub_programs PRIMARY KEY (id)
 );
 
-ALTER TABLE IF EXISTS pdl.programs
+ALTER TABLE IF EXISTS ${SCHEMA}.programs
     ADD CONSTRAINT "fk_ titles_id" FOREIGN KEY (title_id)
-        REFERENCES pdl.titles (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.titles (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE CASCADE
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.programs
+ALTER TABLE IF EXISTS ${SCHEMA}.programs
     ADD CONSTRAINT "fk_ subtitles_id" FOREIGN KEY (subtitle_id)
-        REFERENCES pdl.subtitles (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.subtitles (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE CASCADE
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.sub_programs
+ALTER TABLE IF EXISTS ${SCHEMA}.sub_programs
     ADD CONSTRAINT fk_programs_id FOREIGN KEY (program_id)
-        REFERENCES pdl.programs (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.programs (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE CASCADE
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.payments
+ALTER TABLE IF EXISTS ${SCHEMA}.payments
     ADD CONSTRAINT fk_programs_id FOREIGN KEY (program_id)
-        REFERENCES pdl.programs (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.programs (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE CASCADE
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.payments
+ALTER TABLE IF EXISTS ${SCHEMA}.payments
     ADD CONSTRAINT fk_sub_programs_id FOREIGN KEY (sub_program_id)
-        REFERENCES pdl.sub_programs (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.sub_programs (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE CASCADE
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.payments
+ALTER TABLE IF EXISTS ${SCHEMA}.payments
     ADD CONSTRAINT fk_states_id FOREIGN KEY (state_code)
-        REFERENCES pdl.states (code) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.states (code) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE CASCADE
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.payments
+ALTER TABLE IF EXISTS ${SCHEMA}.payments
     ADD CONSTRAINT fk_titles_id FOREIGN KEY (title_id)
-        REFERENCES pdl.titles (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.titles (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.payments
+ALTER TABLE IF EXISTS ${SCHEMA}.payments
     ADD CONSTRAINT fk_subtitles_id FOREIGN KEY (subtitle_id)
-        REFERENCES pdl.subtitles (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.subtitles (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.payments
+ALTER TABLE IF EXISTS ${SCHEMA}.payments
     ADD CONSTRAINT fk_practice_categories_id FOREIGN KEY (practice_category_id)
-        REFERENCES pdl.practice_categories (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.practice_categories (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.payments
+ALTER TABLE IF EXISTS ${SCHEMA}.payments
     ADD CONSTRAINT fk_practice_code FOREIGN KEY (practice_code)
-        REFERENCES pdl.practices (code) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.practices (code) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.payments
+ALTER TABLE IF EXISTS ${SCHEMA}.payments
     ADD CONSTRAINT fk_sub_sub_programs_id FOREIGN KEY (sub_sub_program_id)
-        REFERENCES pdl.sub_sub_programs (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.sub_sub_programs (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.subtitles
+ALTER TABLE IF EXISTS ${SCHEMA}.subtitles
     ADD CONSTRAINT fk_titles_id FOREIGN KEY (title_id)
-        REFERENCES pdl.titles (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.titles (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE CASCADE
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.practice_categories
+ALTER TABLE IF EXISTS ${SCHEMA}.practice_categories
     ADD CONSTRAINT fk_program_id FOREIGN KEY (program_id)
-        REFERENCES pdl.programs (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.programs (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION
         NOT VALID;
 
 
-ALTER TABLE IF EXISTS pdl.sub_sub_programs
+ALTER TABLE IF EXISTS ${SCHEMA}.sub_sub_programs
     ADD CONSTRAINT fk_sub_programs_id FOREIGN KEY (sub_program_id)
-        REFERENCES pdl.sub_programs (id) MATCH SIMPLE
+        REFERENCES ${SCHEMA}.sub_programs (id) MATCH SIMPLE
         ON UPDATE NO ACTION
         ON DELETE NO ACTION
         NOT VALID;

--- a/queries/drop_tables.sql
+++ b/queries/drop_tables.sql
@@ -1,8 +1,0 @@
-DROP TABLE IF EXISTS pdl.titles;
-DROP TABLE IF EXISTS pdl.programs;
-DROP TABLE IF EXISTS pdl.sub_programs;
-DROP TABLE IF EXISTS pdl.payments;
-DROP TABLE IF EXISTS pdl.states;
-DROP TABLE IF EXISTS pdl.subtitles;
-DROP TABLE IF EXISTS pdl.practices;
-DROP TABLE IF EXISTS pdl.practice_categories;

--- a/queries/initialize_tables.sql
+++ b/queries/initialize_tables.sql
@@ -1,6 +1,6 @@
 -- Populate states table
 
-INSERT INTO pdl.states
+INSERT INTO ${SCHEMA}.states
 VALUES ('AK', 'Alaska'),
        ('AL', 'Alabama'),
        ('AZ', 'Arizona'),
@@ -57,130 +57,130 @@ ON CONFLICT DO NOTHING;
 
 
 -- Titles
-INSERT INTO pdl.titles(name, description)
+INSERT INTO ${SCHEMA}.titles(name, description)
 VALUES ('Title I: Commodities',
         'Title I, Commodities cover price and income support for the farmers who raise widely-produced and traded non-perishable crops, like corn, soybeans, wheat, cotton and rice – as well as dairy and sugar. The title also includes agricultural disaster assistance. The map shows the total benefits paid to farmers from of the commodities programs by state from 2018-2022.')
 ON CONFLICT DO NOTHING;
-INSERT INTO pdl.titles(name, description)
+INSERT INTO ${SCHEMA}.titles(name, description)
 VALUES ('Title II: Conservation',
         'Title II of the law authorizes the Farm Bill’s conservation programs. The programs in this title programs help agricultural producers and landowners adopt conservation activities on private farm and forest lands. In general, conservation activities are intended to protect and improve water quality and quantity, soil health, wildlife habitat, and air quality. The map shows the total benefit of the conservation program by state from 2018-2022.')
 ON CONFLICT DO NOTHING;
-INSERT INTO pdl.titles(name, description)
+INSERT INTO ${SCHEMA}.titles(name, description)
 VALUES ('Title IV: Nutrition',
         'The Supplemental Nutrition Assistance Program [SNAP] provides financial assistance to low-income families to help cover the cost of food. Benefits can only be used to purchase food products and are provided in electronic format similar to a credit card and known as the Electronic Benefit Transfer (EBT) card. The map shows the total SNAP costs of the nutrition title by state from 2018-2022.')
 ON CONFLICT DO NOTHING;
-INSERT INTO pdl.titles(name, description)
+INSERT INTO ${SCHEMA}.titles(name, description)
 VALUES ('Title IX: Crop Insurance',
         'Crop Insurance provides farmers with the option to purchase insurance policies on the acres of crops they plant to help manage the risks of farming, including to indemnify against losses in yields, crop or whole farm revenue, crop margins and other risks. The program also offsets the cost of the insurance policies through premium subsidies. In addition, the program provides Administrative and Operating (A&O) subsidies to the private crop insurance companies who provide federal crop insurance to farmers. The map shows the total farmer net benefit of the crop insurance program by state from 2018-2022.')
 ON CONFLICT DO NOTHING;
 
 -- Title: 1 - Subtitles
-INSERT INTO pdl.subtitles(title_id, name)
+INSERT INTO ${SCHEMA}.subtitles(title_id, name)
 SELECT id, 'Total Commodities Programs, Subtitle A'
-FROM pdl.titles
+FROM ${SCHEMA}.titles
 WHERE name = 'Title I: Commodities';
 
-INSERT INTO pdl.subtitles(title_id, name)
+INSERT INTO ${SCHEMA}.subtitles(title_id, name)
 SELECT id, 'Dairy Margin Coverage, Subtitle D'
-FROM pdl.titles
+FROM ${SCHEMA}.titles
 WHERE name = 'Title I: Commodities';
 
-INSERT INTO pdl.subtitles(title_id, name)
+INSERT INTO ${SCHEMA}.subtitles(title_id, name)
 SELECT id, 'Supplemental Agricultural Disaster Assistance, Subtitle E'
-FROM pdl.titles
+FROM ${SCHEMA}.titles
 WHERE name = 'Title I: Commodities';
 
 -- Title: 1 - Subtitle A - Programs
-INSERT INTO pdl.programs(name, title_id, subtitle_id)
+INSERT INTO ${SCHEMA}.programs(name, title_id, subtitle_id)
 SELECT 'Agriculture Risk Coverage (ARC)',
        id,
-       (SELECT id FROM pdl.subtitles WHERE name = 'Total Commodities Programs, Subtitle A')
-FROM pdl.titles
+       (SELECT id FROM ${SCHEMA}.subtitles WHERE name = 'Total Commodities Programs, Subtitle A')
+FROM ${SCHEMA}.titles
 WHERE name = 'Title I: Commodities';
 
-INSERT INTO pdl.programs(name, title_id, subtitle_id)
+INSERT INTO ${SCHEMA}.programs(name, title_id, subtitle_id)
 SELECT 'Price Loss Coverage (PLC)',
        id,
-       (SELECT id FROM pdl.subtitles WHERE name = 'Total Commodities Programs, Subtitle A')
-FROM pdl.titles
+       (SELECT id FROM ${SCHEMA}.subtitles WHERE name = 'Total Commodities Programs, Subtitle A')
+FROM ${SCHEMA}.titles
 WHERE name = 'Title I: Commodities';
 
 -- Title: 1 - Subtitle D - Programs
 -- N/A
 
 -- Title: 1 - Subtitle E - Programs
-INSERT INTO pdl.programs(name, title_id, subtitle_id)
+INSERT INTO ${SCHEMA}.programs(name, title_id, subtitle_id)
 SELECT 'Emergency Assistance for Livestock, Honey Bees, and Farm-Raised Fish Program (ELAP)',
        id,
-       (SELECT id FROM pdl.subtitles WHERE name = 'Supplemental Agricultural Disaster Assistance, Subtitle E')
-FROM pdl.titles
+       (SELECT id FROM ${SCHEMA}.subtitles WHERE name = 'Supplemental Agricultural Disaster Assistance, Subtitle E')
+FROM ${SCHEMA}.titles
 WHERE name = 'Title I: Commodities';
 
-INSERT INTO pdl.programs(name, title_id, subtitle_id)
+INSERT INTO ${SCHEMA}.programs(name, title_id, subtitle_id)
 SELECT 'Livestock Forage Program (LFP)',
        id,
-       (SELECT id FROM pdl.subtitles WHERE name = 'Supplemental Agricultural Disaster Assistance, Subtitle E')
-FROM pdl.titles
+       (SELECT id FROM ${SCHEMA}.subtitles WHERE name = 'Supplemental Agricultural Disaster Assistance, Subtitle E')
+FROM ${SCHEMA}.titles
 WHERE name = 'Title I: Commodities';
 
-INSERT INTO pdl.programs(name, title_id, subtitle_id)
+INSERT INTO ${SCHEMA}.programs(name, title_id, subtitle_id)
 SELECT 'Livestock Indemnity Payments (LIP)',
        id,
-       (SELECT id FROM pdl.subtitles WHERE name = 'Supplemental Agricultural Disaster Assistance, Subtitle E')
-FROM pdl.titles
+       (SELECT id FROM ${SCHEMA}.subtitles WHERE name = 'Supplemental Agricultural Disaster Assistance, Subtitle E')
+FROM ${SCHEMA}.titles
 WHERE name = 'Title I: Commodities';
 
-INSERT INTO pdl.programs(name, title_id, subtitle_id)
+INSERT INTO ${SCHEMA}.programs(name, title_id, subtitle_id)
 SELECT 'Tree Assistance Program (TAP)',
        id,
-       (SELECT id FROM pdl.subtitles WHERE name = 'Supplemental Agricultural Disaster Assistance, Subtitle E')
-FROM pdl.titles
+       (SELECT id FROM ${SCHEMA}.subtitles WHERE name = 'Supplemental Agricultural Disaster Assistance, Subtitle E')
+FROM ${SCHEMA}.titles
 WHERE name = 'Title I: Commodities';
 
 
 -- Title: 1 - Subtitle A - ARC Program - Subprograms
-INSERT INTO pdl.sub_programs(program_id, name)
+INSERT INTO ${SCHEMA}.sub_programs(program_id, name)
 SELECT id, 'Agriculture Risk Coverage County Option (ARC-CO)'
-FROM pdl.programs
+FROM ${SCHEMA}.programs
 WHERE name = 'Agriculture Risk Coverage (ARC)';
 
-INSERT INTO pdl.sub_programs(program_id, name)
+INSERT INTO ${SCHEMA}.sub_programs(program_id, name)
 SELECT id, 'Agriculture Risk Coverage Individual Coverage (ARC-IC)'
-FROM pdl.programs
+FROM ${SCHEMA}.programs
 WHERE name = 'Agriculture Risk Coverage (ARC)';
 
 -- Title: 2 - Programs
-INSERT INTO pdl.programs(title_id, name)
+INSERT INTO ${SCHEMA}.programs(title_id, name)
 SELECT id, 'Environmental Quality Incentives Program (EQIP)'
-FROM pdl.titles
+FROM ${SCHEMA}.titles
 WHERE name = 'Title II: Conservation';
 
-INSERT INTO pdl.programs(title_id, name)
+INSERT INTO ${SCHEMA}.programs(title_id, name)
 SELECT id, 'Conservation Stewardship Program (CSP)'
-FROM pdl.titles
+FROM ${SCHEMA}.titles
 WHERE name = 'Title II: Conservation';
 
-INSERT INTO pdl.programs(title_id, name)
+INSERT INTO ${SCHEMA}.programs(title_id, name)
 SELECT id, 'Conservation Reserve Program (CRP)'
-FROM pdl.titles
+FROM ${SCHEMA}.titles
 WHERE name = 'Title II: Conservation';
 
-INSERT INTO pdl.programs(title_id, name)
+INSERT INTO ${SCHEMA}.programs(title_id, name)
 SELECT id, 'Agricultural Conservation Easement Program (ACEP)'
-FROM pdl.titles
+FROM ${SCHEMA}.titles
 WHERE name = 'Title II: Conservation';
 
-INSERT INTO pdl.programs(title_id, name)
+INSERT INTO ${SCHEMA}.programs(title_id, name)
 SELECT id, 'Regional Conservation Partnership Program (RCPP)'
-FROM pdl.titles
+FROM ${SCHEMA}.titles
 WHERE name = 'Title II: Conservation';
 
 -- EQIP Practice Categories
 WITH eqip_program_id AS (SELECT id
-                         FROM pdl.programs
+                         FROM ${SCHEMA}.programs
                          WHERE name = 'Environmental Quality Incentives Program (EQIP)')
 INSERT
-INTO pdl.practice_categories(name, display_name, category_grouping, program_id, is_statutory_category)
+INTO ${SCHEMA}.practice_categories(name, display_name, category_grouping, program_id, is_statutory_category)
 VALUES ('Land Management', 'Land management', '(6)(A) Practices', (SELECT id from eqip_program_id), TRUE),
        ('Forest Management', 'Forest management', '(6)(A) Practices', (SELECT id from eqip_program_id), TRUE),
        ('Structural', 'Structural', '(6)(A) Practices', (SELECT id from eqip_program_id), TRUE),
@@ -201,10 +201,10 @@ VALUES ('Land Management', 'Land management', '(6)(A) Practices', (SELECT id fro
 
 -- CSP Practice Categories
 WITH csp_program_id AS (SELECT id
-                        FROM pdl.programs
+                        FROM ${SCHEMA}.programs
                         WHERE name = 'Conservation Stewardship Program (CSP)')
 INSERT
-INTO pdl.practice_categories(name, display_name, category_grouping, program_id, is_statutory_category)
+INTO ${SCHEMA}.practice_categories(name, display_name, category_grouping, program_id, is_statutory_category)
 VALUES ('Cropland', 'Cropland', '2014 Eligible Land', (SELECT id from csp_program_id), FALSE),
        ('Grassland', 'Grassland', '2014 Eligible Land', (SELECT id from csp_program_id), FALSE),
        ('Rangeland', 'Rangeland', '2014 Eligible Land', (SELECT id from csp_program_id), FALSE),
@@ -229,10 +229,10 @@ VALUES ('Cropland', 'Cropland', '2014 Eligible Land', (SELECT id from csp_progra
 
 -- CRP Sub Programs
 WITH crp_program_id AS (SELECT id
-                        FROM pdl.programs
+                        FROM ${SCHEMA}.programs
                         WHERE name = 'Conservation Reserve Program (CRP)')
 INSERT
-INTO pdl.sub_programs(program_id, name)
+INTO ${SCHEMA}.sub_programs(program_id, name)
 VALUES ((SELECT id from crp_program_id), 'Total CRP'),
        ((SELECT id from crp_program_id), 'General Sign-up'),
        ((SELECT id from crp_program_id), 'Continuous Sign-up'),
@@ -240,22 +240,22 @@ VALUES ((SELECT id from crp_program_id), 'Total CRP'),
 
 -- CRP Sub Sub Programs
 WITH crp_sub_program_id AS (SELECT id
-                            FROM pdl.sub_programs
+                            FROM ${SCHEMA}.sub_programs
                             WHERE name = 'Continuous Sign-up')
 INSERT
-INTO pdl.sub_sub_programs(sub_program_id, name)
+INTO ${SCHEMA}.sub_sub_programs(sub_program_id, name)
 VALUES ((SELECT id from crp_sub_program_id), 'CREP Only'),
        ((SELECT id from crp_sub_program_id), 'Continuous Non-CREP'),
        ((SELECT id from crp_sub_program_id), 'Farmable Wetland');
 
 -- Supplemental Nutrition Assistance Program (SNAP)
-INSERT INTO pdl.programs(name, title_id)
+INSERT INTO ${SCHEMA}.programs(name, title_id)
 SELECT 'Supplemental Nutrition Assistance Program (SNAP)', id
-FROM pdl.titles
+FROM ${SCHEMA}.titles
 WHERE name = 'Title IV: Nutrition';
 
 -- Crop Insurance
-INSERT INTO pdl.programs(name, title_id)
+INSERT INTO ${SCHEMA}.programs(name, title_id)
 SELECT 'Crop Insurance', id
-FROM pdl.titles
+FROM ${SCHEMA}.titles
 WHERE name = 'Title IX: Crop Insurance';

--- a/src/main.py
+++ b/src/main.py
@@ -22,14 +22,15 @@ if __name__ == '__main__':
             database.drop_database()
         else:
             print("Continuing without dropping the database")
+    schema_name = cli.args.schema_name
     if cli.args.create_database:
         database.create_database()
     if cli.args.create_schema:
-        database.create_schema()
+        database.create_schema(schema_name)
     if cli.args.create_tables:
-        database.create_tables()
+        database.create_tables(schema_name)
     if cli.args.init_tables:
-        database.initialize_tables()
+        database.initialize_tables(schema_name)
 
     title_i_data_parser = DataParser(2014, 2021, "Title 1: Commodities",
                                      "../data/title-i", "title_1_version_1.csv",
@@ -68,24 +69,24 @@ if __name__ == '__main__':
     if cli.args.insert_data:
         # Title I data ingestion
         logger.info("Starting Title I data ingestion...")
-        database.insert_data(title_i_data_parser.program_data)
-        database.insert_data(title_i_data_parser.dmc_data)
-        database.insert_data(title_i_data_parser.sada_data)
+        database.insert_data(title_i_data_parser.program_data, schema_name)
+        database.insert_data(title_i_data_parser.dmc_data, schema_name)
+        database.insert_data(title_i_data_parser.sada_data, schema_name)
         logger.info("Title I data ingestion complete.")
 
         # Title II data ingestion
         logger.info("Starting Title II data ingestion...")
-        database.insert_data(title_ii_data_parser.program_data)
+        database.insert_data(title_ii_data_parser.program_data, schema_name)
         logger.info("Title II data ingestion complete.")
 
         # Title IV data ingestion
         logger.info("Starting Title IV data ingestion...")
-        database.insert_data(snap_data_parser.snap_data)
+        database.insert_data(snap_data_parser.snap_data, schema_name)
         logger.info("Title IV data ingestion complete.")
 
         # Title XI data ingestion
         logger.info("Starting Title XI data ingestion...")
-        database.insert_data(crop_insurance_data_parser.ci_data)
+        database.insert_data(crop_insurance_data_parser.ci_data, schema_name)
         logger.info("Title XI data ingestion complete.")
 
     database.close()

--- a/src/pdl_cli.py
+++ b/src/pdl_cli.py
@@ -41,6 +41,8 @@ class PolicyDesignLabDataCLI:
                                  help='Construct database if it does not exist.', default=False)
         self.parser.add_argument('--create-schema', '-S', action='store_true',
                                  help='Create schema if it does not exist.', default=False)
+        self.parser.add_argument('--schema-name', '-N', type=str,
+                                 help='Name of the new schema', default='pdl')
         self.parser.add_argument('--init-tables', '-i', action='store_true', help='Initialize tables', default=False)
         self.parser.add_argument('--insert-data', '-I', action='store_true', help='Insert data',
                                  default=False)

--- a/src/pdl_database.py
+++ b/src/pdl_database.py
@@ -68,21 +68,24 @@ class PDLDatabase:
         # connect to the database
         self.connect(db_name=self.db_name, db_user=self.db_user, db_password=self.db_password, db_host=self.db_host)
 
-    def create_schema(self):
+    def create_schema(self, schema_name):
         # create schema
-        self.cursor.execute(f"CREATE SCHEMA IF NOT EXISTS pdl")
+        self.cursor.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
         self.connection.commit()
-        self.logger.info(f"Schema pdl created successfully or already exists")
+        self.logger.info(f"Schema {schema_name} created successfully or already exists")
 
-    def create_tables(self):
-        self._execute_sql_file(self.create_tables_file)
+    def create_tables(self, schema_name):
+        self._execute_sql_file(self.create_tables_file, schema_name)
         self.logger.info("Tables created successfully")
 
     # Function to execute queries from a file
-    def _execute_sql_file(self, filename):
+    def _execute_sql_file(self, filename, schema_name):
         # Open and read the SQL file
         with open(filename, 'r') as file:
             sql_content = file.read()
+
+        # Replace all occurrences of ${SCHEMA} with schema_name
+        sql_content = sql_content.replace('${SCHEMA}', schema_name)
 
         # Split the file into individual statements
         sql_statements = sql_content.split(';')
@@ -102,13 +105,13 @@ class PDLDatabase:
                     self.logger.error(f"An unexpected error occurred: {e}")
                     self.connection.rollback()
 
-    def initialize_tables(self):
-        self._execute_sql_file(self.initialize_tables_file)
+    def initialize_tables(self, schema_name):
+        self._execute_sql_file(self.initialize_tables_file, schema_name)
 
         # Initialize practice standards
         with open(self.merged_practice_standards, 'r') as file:
             data_frame = pd.read_csv(file)
-            sql_insert_query = ("INSERT INTO pdl.practices (code, name, display_name, source) VALUES (%s, %s, %s, %s) "
+            sql_insert_query = (f"INSERT INTO {schema_name}.practices (code, name, display_name, source) VALUES (%s, %s, %s, %s) "
                                 "ON CONFLICT (code) DO UPDATE SET name = EXCLUDED.name, display_name = EXCLUDED.display_name, source = EXCLUDED.source")
 
             for index, row in data_frame.iterrows():
@@ -119,7 +122,7 @@ class PDLDatabase:
 
         self.logger.info("Tables initialized successfully")
 
-    def insert_data(self, data_frame):
+    def insert_data(self, data_frame, schema_name):
         total_rows = len(data_frame)
         # Iterate through the Pandas data frame and insert data into the tables
         for index, row in data_frame.iterrows():
@@ -128,14 +131,14 @@ class PDLDatabase:
 
             if row['entity_type'] == 'subtitle':
                 # Find the title id, and the subtitle id from the subtitles table
-                sql_select_query = "SELECT title_id, id as subtitle_id FROM pdl.subtitles WHERE name = %s"
+                sql_select_query = f"SELECT title_id, id as subtitle_id FROM {schema_name}.subtitles WHERE name = %s"
                 self.cursor.execute(sql_select_query, (row['entity_name'],))
                 result = self.cursor.fetchone()
                 if result:
                     title_id, subtitle_id = result
                     # Insert data into the payments table
                     sql_insert_query = (
-                        "INSERT INTO pdl.payments (title_id, subtitle_id, program_id, sub_program_id, state_code, year, payment, recipient_count, contract_count, base_acres, farm_count) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ")
+                        f"INSERT INTO {schema_name}.payments (title_id, subtitle_id, program_id, sub_program_id, state_code, year, payment, recipient_count, contract_count, base_acres, farm_count) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ")
                     # "ON CONFLICT (title_id, subtitle_id, program_id, sub_program_id, state_code, year) DO UPDATE SET payment = EXCLUDED.payment")
                     self.cursor.execute(sql_insert_query,
                                         (title_id, subtitle_id, None, None, row["state_code"], row['year'],
@@ -150,7 +153,7 @@ class PDLDatabase:
                                              row['farm_count']) else None))
             elif row['entity_type'] == 'program':
                 # Find the program id, title id, and the subtitle id from the program table
-                sql_select_query = "SELECT id, title_id, subtitle_id FROM pdl.programs WHERE name = %s"
+                sql_select_query = f"SELECT id, title_id, subtitle_id FROM {schema_name}.programs WHERE name = %s"
                 self.cursor.execute(sql_select_query, (row['entity_name'],))
                 result = self.cursor.fetchone()
 
@@ -160,13 +163,13 @@ class PDLDatabase:
                     practice_category_id = None
                     # Find practice_category_id from practice_categories table
                     if "practice_category" in row and not pd.isna(row["practice_category"]):
-                        sql_select_query = "SELECT id FROM pdl.practice_categories WHERE name = %s AND program_id = %s"
+                        sql_select_query = f"SELECT id FROM {schema_name}.practice_categories WHERE name = %s AND program_id = %s"
                         self.cursor.execute(sql_select_query, (row['practice_category'], program_id))
                         practice_category_id = self.cursor.fetchone()[0]
 
                     # Insert data into the payments table
                     sql_insert_query = (
-                        "INSERT INTO pdl.payments (title_id, subtitle_id, program_id, sub_program_id, practice_category_id, state_code, year, "
+                        f"INSERT INTO {schema_name}.payments (title_id, subtitle_id, program_id, sub_program_id, practice_category_id, state_code, year, "
                         "payment, recipient_count, base_acres, farm_count, contract_count, practice_code, practice_code_variant, premium_policy_count, "
                         "liability_amount, premium_amount, premium_subsidy_amount, indemnity_amount, farmer_premium_amount, loss_ratio, net_farmer_benefit_amount) "
                         "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
@@ -218,14 +221,14 @@ class PDLDatabase:
             elif row['entity_type'] == 'sub_program':
                 # Find the program id, title id, subtitle id, and sub_program id from joining sub_programs, programs, and titles
                 # tables
-                sql_select_query = "SELECT p.id, p.title_id, p.subtitle_id, s.id FROM pdl.programs p JOIN pdl.sub_programs s ON p.id = s.program_id WHERE s.name = %s"
+                sql_select_query = f"SELECT p.id, p.title_id, p.subtitle_id, s.id FROM {schema_name}.programs p JOIN {schema_name}.sub_programs s ON p.id = s.program_id WHERE s.name = %s"
                 self.cursor.execute(sql_select_query, (row['entity_name'],))
                 result = self.cursor.fetchone()
                 if result:
                     program_id, title_id, subtitle_id, sub_program_id = result
                     # Insert data into the payments table
                     sql_insert_query = (
-                        "INSERT INTO pdl.payments (title_id, subtitle_id, program_id, sub_program_id, state_code, year, payment, recipient_count, contract_count, base_acres, farm_count) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ")
+                        f"INSERT INTO {schema_name}.payments (title_id, subtitle_id, program_id, sub_program_id, state_code, year, payment, recipient_count, contract_count, base_acres, farm_count) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ")
                     # "ON CONFLICT (title_id, subtitle_id, program_id, sub_program_id, state_code, year) DO UPDATE SET payment = EXCLUDED.payment")
                     self.cursor.execute(sql_insert_query,
                                         (title_id, subtitle_id, program_id, sub_program_id, row["state_code"],
@@ -243,14 +246,14 @@ class PDLDatabase:
                 # Find the program id, title id, subtitle id, sub_program id, and sub_sub_program id from joining sub_sub_programs, sub_programs, programs, and titles
                 # tables
 
-                sql_select_query = "SELECT p.id, p.title_id, p.subtitle_id, s.id, ss.id FROM pdl.programs p JOIN pdl.sub_programs s ON p.id = s.program_id JOIN pdl.sub_sub_programs ss ON s.id = ss.sub_program_id WHERE ss.name = %s"
+                sql_select_query = f"SELECT p.id, p.title_id, p.subtitle_id, s.id, ss.id FROM {schema_name}.programs p JOIN {schema_name}.sub_programs s ON p.id = s.program_id JOIN {schema_name}.sub_sub_programs ss ON s.id = ss.sub_program_id WHERE ss.name = %s"
                 self.cursor.execute(sql_select_query, (row['entity_name'],))
                 result = self.cursor.fetchone()
                 if result:
                     program_id, title_id, subtitle_id, sub_program_id, sub_sub_program_id = result
                     # Insert data into the payments table
                     sql_insert_query = (
-                        "INSERT INTO pdl.payments (title_id, subtitle_id, program_id, sub_program_id, sub_sub_program_id, state_code, year, payment, recipient_count, contract_count, base_acres, farm_count) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ")
+                        f"INSERT INTO {schema_name}.payments (title_id, subtitle_id, program_id, sub_program_id, sub_sub_program_id, state_code, year, payment, recipient_count, contract_count, base_acres, farm_count) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ")
                     # "ON CONFLICT (title_id, subtitle_id, program_id, sub_program_id, sub_sub_program_id, state_code, year) DO UPDATE SET payment = EXCLUDED.payment")
                     self.cursor.execute(sql_insert_query,
                                         (title_id, subtitle_id, program_id, sub_program_id, sub_sub_program_id,


### PR DESCRIPTION
This PR introduce a new option `-N` for the command line. `-N` assigns a name for the new schema, and default to `pdl`.

For testing, you can run the commands in the following:
```
python main.py -d "pdl_db" -C -S -N test -c -i -I
```
This will give you a new schema called `test` and its ERD looks identical as pdl's.
Also, all the tables and data will be identical.
Here is the snapshopt of test's ERD: 
![image](https://github.com/user-attachments/assets/8bd865b3-dc21-4e30-8659-0037959b799a)

If you execute commands without option `-N`, a new schema called `pdl` will be created just like what it used to do.
```
python main.py -d "pdl_db" -C -S test -c -i -I
```

