### PR TITLE
Fixes #65 - Create database was not passing in db_port when connecting to database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bug in practice names when there are nested parentheses in the raw
   data [#51](https://github.com/policy-design-lab/data-ingestion/issues/51)
+- Create database was not passing in db_port when connecting to database [#65](https://github.com/policy-design-lab/data-ingestion/issues/65)
 
 ### Changed
 

--- a/src/pdl_database.py
+++ b/src/pdl_database.py
@@ -66,7 +66,8 @@ class PDLDatabase:
         self.close()
 
         # connect to the database
-        self.connect(db_name=self.db_name, db_user=self.db_user, db_password=self.db_password, db_host=self.db_host)
+        self.connect(db_name=self.db_name, db_user=self.db_user, db_password=self.db_password, db_host=self.db_host,
+                     db_port=self.db_port)
 
     def create_schema(self, schema_name):
         # create schema


### PR DESCRIPTION
The first call to connect in create_database was passing in the db_port, but the second call was not, resulting in the connection looking for the DB on the default port. If you were running on a non-default port, then this would fail.